### PR TITLE
feat(imports): update apollo imports to support non-React projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@types/lodash": "^4.14.175",
     "graphql": "^15.6.1",
     "graphql-tag": "^2.12.5",
-    "react": "^17.0.2",
     "wait-for-observables": "^1.0.3"
   },
   "peerDependencies": {

--- a/src/createLazyLoadableLink.test.ts
+++ b/src/createLazyLoadableLink.test.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag'
 import waitFor from 'wait-for-observables'
-import { ApolloLink, execute, Observable, Observer } from '@apollo/client'
+import { ApolloLink, execute, Observable, Observer } from '@apollo/client/core'
 import { createLazyLoadableLink } from './createLazyLoadableLink'
 import { onNextTick, WaitForResult } from './testUtils'
 

--- a/src/createLazyLoadableLink.ts
+++ b/src/createLazyLoadableLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink, Observable } from '@apollo/client'
+import { ApolloLink, Observable } from '@apollo/client/core'
 
 /**
  * Creates a lazy-loadable Apollo Link.

--- a/src/hasOperation.ts
+++ b/src/hasOperation.ts
@@ -1,5 +1,5 @@
 import type { DefinitionNode, OperationTypeNode } from 'graphql'
-import type { Operation } from '@apollo/client'
+import type { Operation } from '@apollo/client/core'
 
 const checkOperationType = (
   definitions: readonly DefinitionNode[],

--- a/src/laika.test.ts
+++ b/src/laika.test.ts
@@ -7,7 +7,7 @@ import {
   Observable,
   Observer,
   Operation,
-} from '@apollo/client'
+} from '@apollo/client/core'
 import { DEFAULT_GLOBAL_PROPERTY_NAME } from './constants'
 import { Laika } from './laika'
 import { onNextTick, WaitForResult } from './testUtils'

--- a/src/laika.ts
+++ b/src/laika.ts
@@ -33,7 +33,7 @@ import {
   Observable,
   Observer,
   Operation,
-} from '@apollo/client'
+} from '@apollo/client/core'
 import type { GenerateCodeOptions } from './codeGenerator'
 import { generateCode } from './codeGenerator'
 import { LOGGING_DISABLED_MATCHER } from './constants'

--- a/src/linkUtils.ts
+++ b/src/linkUtils.ts
@@ -1,5 +1,5 @@
 import isMatch from 'lodash/isMatch'
-import type { Operation } from '@apollo/client'
+import type { Operation } from '@apollo/client/core'
 import type {
   Matcher,
   MatcherFn,

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -4,10 +4,10 @@ import type {
   NextLink,
   Observable,
   Operation,
-} from '@apollo/client'
+} from '@apollo/client/core'
 
 /** @ignore */
-export type { FetchResult, NextLink, Operation } from '@apollo/client'
+export type { FetchResult, NextLink, Operation } from '@apollo/client/core'
 /** @ignore */
 export type Variables = Operation['variables']
 /** @ignore */


### PR DESCRIPTION
This PR removes React as a dev dependency and allows Laika to be used with non-React projects.

`@apollo/client` has a dependency on React as an optional peer dependency. To use `@apollo/client` without React, you need to import from `@apollo/client/core` rather than the default `@apollo/client` package. [See this portion of the Apollo docs for reference. ](https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/#using-apollo-client-without-react)
Since Laika currently imports directly from `@apollo/client`, attempting to use it with non-React projects causes errors when the React peer dependency is not found.

This PR updates Laika imports to use `@apollo/client/core` and removes the React dev dependency since it is no longer required. 

Closes #11 