### PR TITLE
feat: implement onLaikaReady callback for createGlobalLaikaLink

### DIFF
--- a/src/createGlobalLaikaLink.ts
+++ b/src/createGlobalLaikaLink.ts
@@ -1,13 +1,13 @@
 import memoize from 'lodash/memoize'
 import { DEFAULT_GLOBAL_PROPERTY_NAME } from './constants'
 import { Laika } from './laika'
-import type { CreateLaikaLinkOptions, InitialMock } from './typedefs'
+import type { CreateLaikaLinkOptions } from './typedefs'
 
 export const getLaikaSingleton = memoize(
   (
     globalPropertyName: string = DEFAULT_GLOBAL_PROPERTY_NAME,
     startLoggingImmediately: boolean = false,
-    initialMocks: InitialMock[] = [],
+    onLaikaReady?: (laika: Laika) => void,
   ) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-member-access,no-multi-assign
     const singleton = ((globalThis as any)[globalPropertyName] = new Laika({
@@ -18,11 +18,7 @@ export const getLaikaSingleton = memoize(
       singleton.log.startLogging()
     }
 
-    if (initialMocks.length > 0) {
-      initialMocks.forEach(({ interceptorMatcher, mockResult }) => {
-        singleton.intercept(interceptorMatcher).mockResult(mockResult)
-      })
-    }
+    onLaikaReady?.(singleton)
 
     return singleton
   },
@@ -36,7 +32,7 @@ export function createGlobalLaikaLink({
   clientName = '__unknown__',
   globalPropertyName,
   startLoggingImmediately = false,
-  initialMocks = [],
+  onLaikaReady,
 }: CreateLaikaLinkOptions) {
   if (clientName === '__unknown__') {
     throw new Error('LaikaLink: clientName is required')
@@ -44,7 +40,7 @@ export function createGlobalLaikaLink({
   const laika = getLaikaSingleton(
     globalPropertyName,
     startLoggingImmediately,
-    initialMocks,
+    onLaikaReady,
   )
   return laika.createLink((operation) => {
     operation.setContext({ clientName })

--- a/src/createGlobalLaikaLink.ts
+++ b/src/createGlobalLaikaLink.ts
@@ -21,7 +21,7 @@ export const getLaikaSingleton = memoize(
     if (initialMocks.length > 0) {
       initialMocks.forEach(({ interceptorMatcher, mockResult }) => {
         singleton.intercept(interceptorMatcher).mockResult(mockResult)
-      });
+      })
     }
 
     return singleton
@@ -41,7 +41,11 @@ export function createGlobalLaikaLink({
   if (clientName === '__unknown__') {
     throw new Error('LaikaLink: clientName is required')
   }
-  const laika = getLaikaSingleton(globalPropertyName, startLoggingImmediately, initialMocks)
+  const laika = getLaikaSingleton(
+    globalPropertyName,
+    startLoggingImmediately,
+    initialMocks,
+  )
   return laika.createLink((operation) => {
     operation.setContext({ clientName })
   })

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -5,6 +5,7 @@ import type {
   Observable,
   Operation,
 } from '@apollo/client/core'
+import type { Laika } from './laika'
 
 /** @ignore */
 export type { FetchResult, NextLink, Operation } from '@apollo/client/core'
@@ -128,7 +129,7 @@ export interface CreateLaikaLinkOptions {
   clientName: string
   globalPropertyName?: string
   startLoggingImmediately?: boolean
-  initialMocks?: InitialMock[]
+  onLaikaReady?: (laika: Laika) => void
 }
 
 // helpers

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -120,11 +120,6 @@ export interface RecordingMarker {
 
 export type EventFilterFn = (event: RecordingElement) => boolean
 
-export interface InitialMock {
-  interceptorMatcher: MatcherObject
-  mockResult: ResultOrFn
-}
-
 export interface CreateLaikaLinkOptions {
   clientName: string
   globalPropertyName?: string

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -119,10 +119,16 @@ export interface RecordingMarker {
 
 export type EventFilterFn = (event: RecordingElement) => boolean
 
+export interface InitialMock {
+  interceptorMatcher: MatcherObject,
+  mockResult: ResultOrFn,
+}
+
 export interface CreateLaikaLinkOptions {
   clientName: string
   globalPropertyName?: string
   startLoggingImmediately?: boolean
+  initialMocks?: InitialMock[]
 }
 
 // helpers

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -120,8 +120,8 @@ export interface RecordingMarker {
 export type EventFilterFn = (event: RecordingElement) => boolean
 
 export interface InitialMock {
-  interceptorMatcher: MatcherObject,
-  mockResult: ResultOrFn,
+  interceptorMatcher: MatcherObject
+  mockResult: ResultOrFn
 }
 
 export interface CreateLaikaLinkOptions {


### PR DESCRIPTION
After finding need for a similar use-case to https://github.com/zendesk/laika/discussions/9 I decided to take a hand at implementing something simple that would allow for Laika to be used in situations where Apollo queries are made on page load.

In my specific use-case, having a client-level interceptor like Laika would help me conditionally use a mocked dataset without needing to do any extra work on the front-end components, and without needing to worry about the Apollo Server since the project I'm considering this for is using a federated graph.

I have a feeling this approach may be too naive as I haven't spent a lot of time with Laika yet, but I hope this can get the ball rolling and I'd love to hear any feedback or suggestions.

Thanks for the amazing work you've already done, and hope I can contribute to it!