### PR TITLE
docs: add AI-ready repository files

### DIFF
--- a/.cursor/rules/00-core.mdc
+++ b/.cursor/rules/00-core.mdc
@@ -1,0 +1,9 @@
+---
+description: Core project conventions
+globs: ["**/*"]
+alwaysApply: true
+---
+
+Read and follow all instructions in the root `AGENTS.md` file.
+Read and follow all security requirements in `SECURITY.md`.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Copilot Instructions
+
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,3 @@
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,140 @@
+# Laika
+
+Laika is an Apollo Client testing library for intercepting, mocking, and recording GraphQL operations (queries, mutations, subscriptions) in both browser and unit test environments. Published as `@zendesk/laika` on npm; built with TypeScript and distributed as dual CJS + ESM.
+
+## Setup & Commands
+
+```bash
+# Install dependencies
+yarn install --immutable
+
+# Build CJS and ESM distributions
+yarn build
+
+# Run all checks (format + types + lint + compat + unit tests)
+yarn test
+
+# Run Jest unit tests only
+yarn test:code
+
+# Run unit tests with coverage
+yarn test:code --coverage
+
+# Check Prettier formatting
+yarn test:format
+
+# Auto-format code
+yarn format
+
+# Check TypeScript types
+yarn test:types
+
+# Run ESLint
+yarn test:lint
+
+# Run Apollo 3/4 compatibility tests (requires build first)
+yarn test:compat
+```
+
+Node version is pinned — see `.node-version`. Dependency versions: see `package.json`.
+
+## Directory Guide
+
+```
+src/                          # Library source (TypeScript)
+  main.ts                     # Public exports entry point
+  laika.ts                    # Core Laika class, InterceptApi, LogApi
+  createGlobalLaikaLink.ts    # Global singleton link factory
+  createLazyLoadableLaikaLink.ts  # Lazy-load wrapper for production use
+  createLazyLoadableLink.ts   # Generic lazy-loadable Apollo Link helper
+  typedefs.ts                 # All TypeScript type definitions
+  linkUtils.ts                # Matcher resolution & emit helpers
+  hasOperation.ts             # GraphQL operation type detection
+  observableUtils.ts          # Observable mapping utilities
+  codeGenerator.ts            # Mock code generation from recordings
+  constants.ts                # Global constants
+  testUtils.ts                # Shared test helpers
+tests/compat/                 # Apollo 3 and 4 compatibility test fixtures
+scripts/                      # Release and compat test scripts
+docs/                         # Docusaurus documentation site (separate workspace)
+```
+
+## Code Conventions
+
+- **TypeScript strict mode** — all source under `src/` must pass `tsc --noEmit`
+- **Named exports only** — no default exports in library source
+- **Dual format** — compile to both `cjs/` (CommonJS) and `esm/` (ES modules)
+- **Naming**: `PascalCase` for classes/types/interfaces, `camelCase` for functions/variables, `UPPER_SNAKE` for top-level constants
+- **Formatting**: Prettier enforced — 2-space indent, single quotes, no semicolons, trailing commas, always-parens for arrow functions
+- **No tabs** — ESLint enforces `no-tabs`
+- **Lodash utilities** — prefer lodash helpers (`isMatch`, `memoize`, `camelCase`, etc.) over rolling your own
+- Tests live **co-located** in `src/` as `*.test.ts`; integration tests as `src/integration.test.ts`
+- Source uses `Observable` from `@apollo/client/core` — do **not** import from `rxjs` directly (rxjs is an optional peer dep for subscription support only)
+
+## Testing
+
+- Framework: **Jest** with SWC transformer (`@swc/jest`)
+- Test files: `src/**/*.test.ts` (co-located with source)
+- Run a single file: `yarn test:code -- src/laika.test.ts`
+- Run with coverage: `yarn test:code --coverage --runInBand`
+- Compat tests validate the built package against Apollo 3 and Apollo 4 — run `yarn build` first
+- Coverage thresholds are defined in `jest.config.js`
+
+## Do
+
+- Export all public types from `src/main.ts`
+- Use `ApolloLink` and `Observable` from `@apollo/client/core` for Apollo compatibility
+- Use `getMatcherFn()` from `linkUtils.ts` when resolving `Matcher` inputs
+- Use `mapObservable()` from `observableUtils.ts` for transforming Observables
+- Write JSDoc comments on all public API methods (they generate the docs site via TypeDoc)
+- Maintain Apollo 3 + 4 compatibility — test with `yarn test:compat` after changes to link internals
+- Use `getLaikaSingleton()` (memoized) for global instances — don't create new `Laika()` instances outside tests
+- Clean up interceptors in tests via `laika.mockRestoreAll()` in `afterEach`
+
+## Don't
+
+- Don't add runtime dependencies without careful consideration — this is a library and bundle size matters
+- Don't use `rxjs` Observable directly in library source (keep Apollo 3 compatibility)
+- Don't commit built artifacts (`cjs/`, `esm/`, `dist/`) — these are gitignored and CI-generated
+- Don't use default exports in `src/`
+- Don't use `console.log` in library code (except in the intentional logging/recording APIs inside `laika.ts`)
+- Don't skip the compat tests when changing link internals — `yarn test:compat` is required
+
+## Architecture
+
+See `ARCHITECTURE.md` for system architecture, component relationships, and design decisions.
+
+## Security
+
+See `SECURITY.md` for mandatory security requirements, prohibited patterns, and escalation triggers.
+
+## Safety & Permissions
+
+Allowed without approval:
+- Read/list files
+- Run individual test files and linters
+- Run type check on specific files
+
+Ask before:
+- Installing or removing packages
+- Deleting files or directories
+- Running full test suite or build
+- Modifying CI/CD configuration
+- Publishing or creating releases
+
+## PR & Commit Guidelines
+
+- Commit format: `type(scope): description` (conventional commits, enforced by commitlint)
+- Allowed types: `feat`, `fix`, `chore`, `ci`, `docs`, `perf`, `refactor`, `revert`, `style`, `test`, `build`, `wip`
+- Branch naming: `username/verb-noun` (e.g., `alice/fix-subscription-leak`)
+- PRs require at least one approval and passing CI before merge
+- Maintainers squash-merge using the PR title as the conventional commit message
+- See `.github/CONTRIBUTING.md` for full workflow
+
+## References
+
+- Architecture: `ARCHITECTURE.md`
+- Security: `SECURITY.md`
+- Contributing: `.github/CONTRIBUTING.md`
+- Docs site source: `docs/`
+- Published docs: https://zendesk.github.io/laika/docs/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,108 @@
+# Laika Architecture
+
+## System Overview
+
+Laika is an Apollo Link middleware library that sits between Apollo Client and your actual network link. It intercepts all GraphQL operations (queries, mutations, subscriptions) in flight and allows tests to mock responses, record real network traffic, and fire subscription updates on demand. The package is distributed as dual CJS + ESM and is designed to be lazily loaded so it has zero impact on production bundle size when not active.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    App["Your App\n(Apollo Client)"]
+    LL["createLazyLoadableLaikaLink\n(production entry)"]
+    GL["createGlobalLaikaLink\n(direct entry)"]
+    L["Laika singleton\n(globalThis.laika)"]
+    Link["Laika ApolloLink\n(laika.createLink())"]
+    Network["Network / downstream links"]
+    Test["Test / Browser Console\n(laika.intercept, laika.log)"]
+
+    App -->|"Apollo Link chain"| LL
+    App -->|"Apollo Link chain"| GL
+    LL -->|"lazy import"| GL
+    GL -->|"getLaikaSingleton()"| L
+    L -->|"createLink()"| Link
+    Link -->|"passthrough / mock decision"| Network
+    Test -->|"intercept() / log / record"| L
+```
+
+## Component Map
+
+| File | Responsibility | Key Dependencies |
+|------|---------------|-----------------|
+| `src/main.ts` | Public package exports | All public modules |
+| `src/laika.ts` | Core `Laika` class: intercept management, logging, recording, code gen | `linkUtils`, `hasOperation`, `codeGenerator`, `observableUtils` |
+| `src/createGlobalLaikaLink.ts` | Installs Laika singleton on `globalThis`; creates named Apollo Link | `laika.ts`, `constants.ts` |
+| `src/createLazyLoadableLaikaLink.ts` | Production-safe lazy-load entry point; defers import of Laika until needed | `createLazyLoadableLink.ts` |
+| `src/createLazyLoadableLink.ts` | Generic Apollo Link wrapper that resolves a `Promise<ApolloLink>` | `@apollo/client/core` |
+| `src/typedefs.ts` | All TypeScript types and interfaces | `@apollo/client/core`, `graphql` |
+| `src/linkUtils.ts` | Resolves `Matcher` → `MatcherFn`; builds emit callbacks | `hasOperation.ts` |
+| `src/hasOperation.ts` | Detects operation types (query/mutation/subscription) from GraphQL AST | `graphql` |
+| `src/observableUtils.ts` | `mapObservable` helper for transforming Observables | `@apollo/client/core` |
+| `src/codeGenerator.ts` | Generates reproducible Jest mock code from recorded sessions | `typedefs`, lodash |
+| `src/constants.ts` | `DEFAULT_GLOBAL_PROPERTY_NAME` (`"laika"`), disabled-logging sentinel | — |
+| `src/testUtils.ts` | Shared test utilities for unit tests | — |
+
+## Request Flow
+
+### Interception (mocking)
+1. Apollo Client fires an operation → traverses the Link chain → reaches `LaikaLink`
+2. `LaikaLink` looks up registered `Behavior` entries in `laika.behaviors` (via `interceptor()`)
+3. If a matching `Behavior` is found, `onSubscribe()` is called — it emits mock results or enables passthrough
+4. If no behavior matches, the operation is added to `unmatchedOperationOptions` and passes through to the network
+5. Test code calls `laika.intercept(matcher)` → returns `InterceptApi`; subsequent `mockResult()` / `fireSubscriptionUpdate()` calls deliver data directly to active observers
+
+### Logging / Recording
+1. `laika.log.startLogging()` sets `loggingMatcher`
+2. Every operation result passes through `getLogFunction()` (via `mapObservable` wrapping the interceptor)
+3. If recording is active, results are appended to `this.recording[]`
+4. `laika.log.generateMockCode()` passes `recording` to `codeGenerator.ts` → returns a code snippet
+
+### Lazy Loading (production)
+1. App bundles `createLazyLoadableLaikaLink` — only a tiny stub at startup
+2. When the stub's first operation fires, it dynamically `import()`s `createGlobalLaikaLink`
+3. The real `Laika` singleton is created and registered on `globalThis` under `laika`
+4. Subsequent operations route through the real link; browser console can now call `window.laika.*`
+
+## Key Design Decisions
+
+### Interceptor-first, passthrough by default
+Unmatched operations pass through to the real network link transparently. This makes Laika safe to add to production bundles — it only takes effect when test code calls `laika.intercept()`.
+
+### Global singleton via `getLaikaSingleton` (memoized)
+Multiple Apollo Clients (each with a named `clientName`) all share one `Laika` instance. This lets tests coordinate across clients and is why the default global property is `window.laika`.
+
+### Lazy loading for zero production overhead
+`createLazyLoadableLaikaLink` uses dynamic `import()` so Laika's code is a separate webpack chunk. Production builds load it only when a flag is set (e.g., an env variable or cookie), keeping the main bundle small.
+
+### Apollo 3 + 4 dual compatibility
+The library avoids rxjs Observables in its core (uses `@apollo/client/core`'s `Observable`) and is tested against both Apollo 3 and Apollo 4 via the `tests/compat/` suite.
+
+### Dual CJS + ESM distribution
+Built with `tsc` twice — once targeting CommonJS for Node.js test runners and once targeting ES modules for bundlers. Package `exports` field resolves both.
+
+## External Dependencies
+
+| Dependency | Role | Notes |
+|------------|------|-------|
+| `@apollo/client` | Peer dep; `ApolloLink`, `Observable` | Supports `>=3.2.5 <5` |
+| `graphql` | Peer dep; AST types, `print()` | `^15 \|\| ^16` |
+| `rxjs` | Optional peer dep; subscription support for Apollo 4 | `^7.3.0` |
+| `lodash` | Runtime dep; `isMatch`, `memoize`, code-gen utilities | Tree-shakeable imports |
+
+## Build & Distribution
+
+- `yarn build:cjs` → `cjs/` (CommonJS, ES2015 target)
+- `yarn build:esm` → `esm/` (ES modules, ES2015 target)
+- `package.json` `exports` field maps `import` → `esm/main.js`, `require` → `cjs/main.js`
+- Releasing: semantic-release driven by conventional commits on `main` / `master`
+
+## Cross-Cutting Concerns
+
+### TypeScript
+Strict mode enabled with `noUncheckedIndexedAccess`, `noImplicitOverride`, `noImplicitReturns`. All types exported from `src/typedefs.ts`.
+
+### Testing
+Jest + SWC. Unit tests co-located with source (`src/*.test.ts`). Compat tests in `tests/compat/` are run against the built package to validate real consumer scenarios.
+
+### Docs
+`docs/` is a separate Docusaurus workspace. API reference pages are generated from JSDoc comments via TypeDoc. Docs deploy to GitHub Pages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Configuration
+
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,167 @@
+# AI Agent Security Standard
+
+This document defines mandatory security principles and restrictions for all AI coding assistants operating in this repository. All AI agents must follow these requirements without exception.
+
+**Authority:** Derived from [Zendesk Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/) and internal security policies.
+
+---
+
+## Core Security Mandate
+
+Security is a first-class requirement. Every code suggestion must be evaluated against these guidelines. If a request would result in insecure code:
+
+1. **Stop** and flag the security concern
+2. **Explain** why it's problematic
+3. **Propose** a secure alternative
+
+AI-generated code requires human review before merging.
+
+---
+
+## Absolute Prohibitions
+
+AI agents must **NEVER** do the following:
+
+### Secrets & Credentials
+- Hardcode secrets, credentials, API keys, tokens, or passwords in source code
+- Store secrets in version control (`.env` files, config with real values)
+- Log, print, or expose secret values
+- Expose credentials in URLs, logs, or error messages
+
+### Security Controls
+- Disable or weaken security controls
+- Bypass authentication or authorization checks
+- Disable certificate validation
+- Weaken password policies or MFA requirements
+
+### Dangerous Code Patterns
+- Generate code using raw string interpolation of untrusted input
+- Use `eval()` or `exec()` with user-supplied input
+- Implement custom cryptography
+- Use deprecated algorithms (MD5, SHA-1, DES, RC4, ECB mode)
+
+### Data Exposure
+- Log sensitive data (PII, credentials, tokens, customer data)
+- Expose stack traces or internal paths to end users
+- Transmit sensitive data over unencrypted channels
+
+---
+
+## Required Security Patterns
+
+### NPM Package Publishing
+
+```bash
+# Correct: use the TOTP-protected release script
+yarn release
+# This calls scripts/npm-release-with-totp.mjs which requires NPM_TOKEN
+# and NPM_TOTP_DEVICE environment variables — never hardcode these
+```
+
+```bash
+# NEVER: publish directly with credentials inline
+NPM_TOKEN=abc123 npm publish
+```
+
+### Environment Variables
+
+```typescript
+// Correct: access secrets via environment variables
+const npmToken = process.env.NPM_TOKEN
+```
+
+```typescript
+// NEVER: hardcode tokens or API keys
+const npmToken = "npm_abc123XYZ"
+```
+
+### Logging in Library Code
+
+```typescript
+// Correct: log only operation metadata and result shape
+console.log(`LOG:GQL ${clientName}: ${type}`, { operation, result })
+```
+
+```typescript
+// NEVER: log authentication headers, tokens, or PII in operation context
+console.log('operation context:', operation.getContext()) // context may contain auth headers
+```
+
+---
+
+## Security Requirements by Domain
+
+### npm Release Pipeline
+- Releases are gated behind semantic-release on `main`/`master`/`next` branches only
+- NPM authentication uses `NPM_TOKEN` + TOTP from `NPM_TOTP_DEVICE` (both GitHub secrets)
+- Release scripts (`scripts/npm-release-with-totp.mjs`, `scripts/release.mjs`) must not be modified to weaken these gates
+- Never add direct `npm publish` commands that bypass the TOTP gate
+
+### Dependency Management
+- `yarn install --immutable` is enforced in CI — do not bypass with `--no-immutable`
+- Dependabot is configured (`.github/dependabot.yml`) — keep it enabled
+- Do not add `resolutions` overrides that force vulnerable package versions
+
+### GraphQL Operation Context
+- Apollo operation context may contain auth headers or tokens set by upstream links
+- Never log `operation.getContext()` raw output in library code
+- Matcher functions receive `Operation` objects — do not log or expose variables that may contain PII
+
+### CI/CD Secrets
+- GitHub Actions secrets (`NPM_TOKEN`, `NPM_TOTP_DEVICE`, `GITHUB_TOKEN`) must remain in GitHub secrets
+- Do not add steps that echo or print these values
+- The `npm-publish` environment requires both checks and test jobs to pass first
+
+### Cryptography
+| Use Case | Approved | Forbidden |
+|----------|----------|-----------|
+| Integrity hashing | SHA-256, SHA-3 | MD5, SHA-1 |
+| Symmetric encryption | AES-256-GCM | DES, 3DES, AES-ECB |
+| TLS | TLS 1.2+ | SSLv2/3, TLS 1.0/1.1 |
+
+### Error Handling
+- Do not expose internal stack traces to end users
+- Errors passed to Apollo observers should be `Error` instances, not raw strings containing sensitive data
+- The `toError()` pattern in `laika.ts` (converting unknown throws to `Error`) is the correct approach
+
+---
+
+## When to Stop and Escalate
+
+Stop, explain the concern, and recommend involving Security if a task requires:
+
+- Modifying the npm release pipeline to skip authentication or TOTP verification
+- Adding new GitHub Actions steps that access or echo CI secrets
+- Disabling Dependabot or suppressing security alerts
+- Implementing custom crypto or auth logic
+- Accessing or logging raw Apollo operation context that may contain auth headers
+- Bypassing the semantic-release branch restrictions
+- Working around the `--immutable` yarn lockfile enforcement
+
+---
+
+## Security Testing
+
+When generating features, include:
+
+- Tests that verify interceptors do not leak operation context or variables unintentionally
+- Tests for error paths to ensure `Error` objects are propagated correctly (not raw strings)
+- Negative test cases for invalid matcher inputs and empty recording states
+
+---
+
+## Reporting Vulnerabilities
+
+If you discover a security vulnerability in this package, please report it via GitHub's [private vulnerability reporting](https://github.com/zendesk/laika/security/advisories/new) or contact [security@zendesk.com](mailto:security@zendesk.com).
+
+---
+
+## References
+
+- [Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/)
+- [Cryptography Standards](https://techmenu.zende.sk/standards/cryptography-standards/)
+- [Unified JWT Standard](https://techmenu.zende.sk/standards/unified-jwt/)
+
+---
+
+**Questions?** Reach out to the Security team or file a ticket via the Security Engagement process.


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` — vendor-neutral hub with project overview, commands, conventions, directory guide, do/don't lists, and PR guidelines for all AI coding assistants
- Add `ARCHITECTURE.md` — system diagram, component map, request flow (intercept + logging + lazy loading), and key design decisions
- Add `SECURITY.md` — security mandate, absolute prohibitions, required patterns (npm release pipeline, secrets, logging), and escalation triggers

## Tool-specific spokes (thin references to AGENTS.md + SECURITY.md)

- `CLAUDE.md` — Claude Code entry point
- `.github/copilot-instructions.md` — GitHub Copilot entry point
- `.cursor/rules/00-core.mdc` — Cursor entry point
- `.windsurfrules` — Windsurf entry point

## Test plan

- [ ] Review `AGENTS.md` for accuracy: commands, directory structure, conventions match actual codebase
- [ ] Review `ARCHITECTURE.md` diagram and component map match actual `src/` layout
- [ ] Review `SECURITY.md` prohibitions are appropriate for this npm library / release pipeline
- [ ] Confirm no existing source files were modified

---
Requested by @nimishadoongarwal via [zendesk/ai-repo#380](https://github.com/zendesk/ai-repo/issues/380)