### PR TITLE
fix: resolve npm-publish environment secrets in bootstrap workflow

### DIFF
--- a/.github/workflows/npm-trusted-publishing.yml
+++ b/.github/workflows/npm-trusted-publishing.yml
@@ -5,10 +5,10 @@ on:
 
 jobs:
   bootstrap:
+    # NPM credentials live in the npm-publish environment, not repo secrets.
+    environment: npm-publish
     uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
+    secrets: inherit
     with:
       package-name: '@zendesk/laika'
       package-json-file-path: package.json

--- a/scripts/npm-release-with-oidc.mjs
+++ b/scripts/npm-release-with-oidc.mjs
@@ -118,10 +118,14 @@ const exchangeNpmToken = async () => {
   const responseBody = await readJsonResponse(response)
 
   if (!response.ok) {
+    const npmMessage = responseBody.message ?? response.statusText
+    const bootstrapHint =
+      response.status === 404
+        ? ' Run the "npm trusted publishing" workflow to register ci-cd.yml as the trusted publisher for this package.'
+        : ''
+
     throw new Error(
-      `npm OIDC token exchange failed with ${response.status}: ${
-        responseBody.message ?? response.statusText
-      }`,
+      `npm OIDC token exchange failed with ${response.status}: ${npmMessage}.${bootstrapHint}`,
     )
   }
 


### PR DESCRIPTION
## Summary
- Add `environment: npm-publish` to the bootstrap job so `NPM_TOKEN` and `NPM_TOTP_DEVICE` resolve from the environment where laika stores them (not repo-level secrets).
- Switch to `secrets: inherit` per the `zendesk/gw` trusted publishing workflow docs.
- Improve the OIDC 404 error message to point at the bootstrap workflow when trusted publishing is not registered yet.

## Context
After #103 merged, two workflows failed:
- [bootstrap run](https://github.com/zendesk/laika/actions/runs/28477204875/job/84404696414): `curl: (22) The requested URL returned error: 401` while configuring the trusted publisher — secrets were empty because the caller job had no environment.
- [publish run](https://github.com/zendesk/laika/actions/runs/28477049721/job/84404388245): `OIDC token exchange error - package not found` — expected until trusted publishing is bootstrapped.

## Test plan
- [ ] Merge this PR
- [ ] Re-run the **npm trusted publishing** workflow (`workflow_dispatch`) and confirm the "Configure trusted publisher" step succeeds
- [ ] Re-run the failed **Continuous Integration** publish job (or push a no-op commit) and confirm `yarn release` completes via OIDC

Made with [Cursor](https://cursor.com)