### PR TITLE
chore: test gw#19 npm trusted publishing bootstrap workflow

### DIFF
--- a/.github/workflows/npm-trusted-publishing.yml
+++ b/.github/workflows/npm-trusted-publishing.yml
@@ -5,9 +5,8 @@ on:
 
 jobs:
   bootstrap:
-    # NPM credentials live in the npm-publish environment, not repo secrets.
-    environment: npm-publish
-    uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
+    # Test-driving gw#19 before it lands on @main. Switch ref to @main after zendesk/gw#19 merges.
+    uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@fix/npm-trusted-publication-environment-secrets
     secrets: inherit
     with:
       package-name: '@zendesk/laika'

--- a/.github/workflows/npm-trusted-publishing.yml
+++ b/.github/workflows/npm-trusted-publishing.yml
@@ -11,11 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24.14.1'
-          registry-url: https://registry.npmjs.org
-
       - uses: zendesk/gw/.github/actions/npm-trusted-publication@fix/npm-trusted-publication-environment-secrets
         with:
           package-name: '@zendesk/laika'

--- a/.github/workflows/npm-trusted-publishing.yml
+++ b/.github/workflows/npm-trusted-publishing.yml
@@ -5,12 +5,24 @@ on:
 
 jobs:
   bootstrap:
-    # Test-driving gw#19 before it lands on @main. Switch ref to @main after zendesk/gw#19 merges.
-    uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@fix/npm-trusted-publication-environment-secrets
-    secrets: inherit
-    with:
-      package-name: '@zendesk/laika'
-      package-json-file-path: package.json
-      publish-workflow: ci-cd.yml
-      repository: ${{ github.repository }}
-      github-environment: npm-publish
+    # Test-driving gw#19 via composite action. Switch ref to @main after zendesk/gw#19 merges.
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.14.1'
+          registry-url: https://registry.npmjs.org
+
+      - uses: zendesk/gw/.github/actions/npm-trusted-publication@fix/npm-trusted-publication-environment-secrets
+        with:
+          package-name: '@zendesk/laika'
+          package-json-file-path: package.json
+          publish-workflow: ci-cd.yml
+          repository: ${{ github.repository }}
+          github-environment: npm-publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}


### PR DESCRIPTION
## Summary
- Replace the invalid `environment` + `uses` bootstrap caller with the gw#19 reusable workflow pinned to `fix/npm-trusted-publication-environment-secrets`.
- Use `secrets: inherit` so npm credentials resolve from the `npm-publish` environment inside the reusable workflow job.

Depends on [zendesk/gw#19](https://github.com/zendesk/gw/pull/19).

After gw#19 merges, switch the ref from `@fix/npm-trusted-publication-environment-secrets` to `@main`.

## Test plan
- [ ] Merge this PR (or run the workflow from this branch)
- [ ] Run **npm trusted publishing** (`workflow_dispatch`)
- [ ] Confirm **Validate npm credentials** and **Configure trusted publisher** succeed (no 401)
- [ ] Re-run the failed CI publish job and confirm OIDC release works
- [ ] After gw#19 lands on `main`, follow up to pin `@main` and close [PR #106](https://github.com/zendesk/laika/pull/106) if still open

Made with [Cursor](https://cursor.com)