### PR TITLE
fix: restore canonical npm trusted publishing bootstrap workflow

### DIFF
--- a/.github/workflows/npm-trusted-publishing.yml
+++ b/.github/workflows/npm-trusted-publishing.yml
@@ -5,10 +5,10 @@ on:
 
 jobs:
   bootstrap:
-    # NPM credentials live in the npm-publish environment, not repo secrets.
-    environment: npm-publish
     uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
     with:
       package-name: '@zendesk/laika'
       package-json-file-path: package.json


### PR DESCRIPTION
## Summary
Restore `.github/workflows/npm-trusted-publishing.yml` to the documented [zendesk/gw reusable workflow](https://github.com/zendesk/gw/blob/main/.github/workflows/npm-trusted-publication.yml) caller pattern with an explicit `secrets:` block.

This also repairs `main`, which currently fails workflow validation: PR #105 merged an invalid `environment` + `uses` combination (reusable-workflow callers cannot set `environment`).

## Root cause
The original bootstrap 401 was a **missing prerequisite**, not a workflow-logic bug. Per the [trusted publishing docs](https://zendeskdev.zendesk.com/hc/en-us/articles/5881574210330-Self-service-Github-Actions-organisation-secrets), the repo must have org access to both `NPM_TOKEN` and `NPM_TOTP_DEVICE`:

- laika **was** in `NPM_TOTP_DEVICE.json` → resolves fine
- laika was **never** in `NPM_TOKEN.json` → `NPM_TOKEN` only existed in the `npm-publish` environment, so it resolved **empty** in the `workflow_dispatch` caller context → npm `401`

The org-secret access is added in zendesk/github-actions-secrets#330. Once that syncs, this standard workflow resolves both secrets correctly.

## Supersedes
- Closes #106 (inlined bootstrap)
- Closes #107 (composite-action test branch)
- No gw changes needed (gw#19 closed)

## Test plan
- [ ] Merge github-actions-secrets#330 and confirm `NPM_TOKEN` syncs to laika
- [ ] Merge this PR
- [ ] Run **npm trusted publishing** (`workflow_dispatch`) → confirm trusted publisher is configured (no 401)
- [ ] Push to `main` (or re-run CI publish) → confirm `yarn release` publishes via OIDC

Made with [Cursor](https://cursor.com)